### PR TITLE
adding INKBIRD Bluetooth Pool Thermometer IBS-P01B

### DIFF
--- a/source/_integrations/inkbird.markdown
+++ b/source/_integrations/inkbird.markdown
@@ -20,6 +20,7 @@ Integrates [INKBIRD](https://www.inkbird.com/) devices into Home Assistant.
 ## Supported devices
 
 - [INKBIRD Bluetooth Thermometer IBS-TH1](https://inkbird.com/products/bluetooth-thermometer-ibs-th1)
+- [INKBIRD Bluetooth Pool Thermometer IBS-P01B](https://inkbird.com/products/bluetooth-pool-thermometer-ibs-p01b)
 - [INKBIRD Temperature and humidity Hygrometer IBS-TH2](https://inkbird.com/products/hygrometer-ibs-th2)
 - [INKBIRD Bluetooth Smart Sensor ITH-12S](https://inkbird.com/products/bluetooth-smart-sensor-ith-12s)
 - [INKBIRD Bluetooth BBQ Thermometer IBT-6XS](https://inkbird.com/products/bluetooth-bbq-thermometer-ibt-6xs)


### PR DESCRIPTION
## Proposed change
adding the INKBIRD Bluetooth Pool Thermometer IBS-P01B as a supported device


## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
The INKBIRD Bluetooth Pool Thermometer IBS-P01B was automatically detected by Home Assistant and temperature and battery report back every 5 minutes. Adding this as a supported device to the documentation.

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
